### PR TITLE
Audit standalone

### DIFF
--- a/docs/source/audit/getting-started-audit.rst
+++ b/docs/source/audit/getting-started-audit.rst
@@ -82,20 +82,22 @@ Running the Audit Only as part of remediate playbook
 
 It is possible to just run the audit on some playbooks (being rolled out across them all). This is a variable set
 
-```
+.. code-block:: yaml
+
 audit_only: true
-```
+
 
 This will run the audit based on the same release as the playbook and will then stop.
 Extra variables also enable the ability to copy back the audit output to the control node and create a directory structure.
 
-```
+.. code-block:: yaml
+
 # As part of audit_only
 # This will enable files to be copied back to control node
 fetch_audit_files: false
 # Path to copy the files to will create dir structure
 audit_capture_files_dir: /some/location to copy to on control node
-```
+
 
 Defining the audit
 ------------------

--- a/docs/source/audit/getting-started-audit.rst
+++ b/docs/source/audit/getting-started-audit.rst
@@ -84,7 +84,7 @@ It is possible to just run the audit on some playbooks (being rolled out across 
 
 .. code-block:: yaml
 
-audit_only: true
+  audit_only: true
 
 
 This will run the audit based on the same release as the playbook and will then stop.
@@ -92,11 +92,11 @@ Extra variables also enable the ability to copy back the audit output to the con
 
 .. code-block:: yaml
 
-# As part of audit_only
-# This will enable files to be copied back to control node
-fetch_audit_files: false
-# Path to copy the files to will create dir structure
-audit_capture_files_dir: /some/location to copy to on control node
+  # As part of audit_only
+  # This will enable files to be copied back to control node
+  fetch_audit_files: false
+  # Path to copy the files to will create dir structure
+  audit_capture_files_dir: /some/location to copy to on control node
 
 
 Defining the audit

--- a/docs/source/audit/getting-started-audit.rst
+++ b/docs/source/audit/getting-started-audit.rst
@@ -77,6 +77,26 @@ The following requirements are needed (OS dependant)
     The binary only needs to be accessible to the host with ability to use.
     The relevant script needs to be adjust to point to the path of the binary.
 
+Running the Audit Only as part of remediate playbook
+----------------------------------------------------
+
+It is possible to just run the audit on some playbooks (being rolled out across them all). This is a variable set
+
+```
+audit_only: true
+```
+
+This will run the audit based on the same release as the playbook and will then stop.
+Extra variables also enable the ability to copy back the audit output to the control node and create a directory structure.
+
+```
+# As part of audit_only
+# This will enable files to be copied back to control node
+fetch_audit_files: false
+# Path to copy the files to will create dir structure
+audit_capture_files_dir: /some/location to copy to on control node
+```
+
 Defining the audit
 ------------------
 


### PR DESCRIPTION
**Overall Review of Changes:**
Additional documentation to enable audit only for remediation

**How has this been tested?:**
https://ansible-lockdown.readthedocs.io/en/audit_standalone/audit/getting-started-audit.html#running-the-audit-only-as-part-of-remediate-playbook