### PR TITLE
Refresh CIS/STIG benchmark tables and add Molecule testing guide

### DIFF
--- a/docs/source/CIS/CIS_table.rst
+++ b/docs/source/CIS/CIS_table.rst
@@ -31,7 +31,7 @@ Operating Systems
    "Windows-2016-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/Windows-2016-CIS?style=plastic"
    "Windows-2019-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/Windows-2019-CIS?style=plastic"
    "Windows-2022-CIS_", "True", "True", "WIP", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/Windows-2022-CIS?style=plastic"
-   "Windows-2025-CIS_", "True", "True", "WIP", "N/A"
+   "Windows-2025-CIS_", "True", "True", "WIP", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/Windows-2025-CIS?style=plastic"
 
 Cloud Platforms
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/CIS/CIS_table.rst
+++ b/docs/source/CIS/CIS_table.rst
@@ -12,13 +12,15 @@ Operating Systems
    "AMAZON2023-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/AMAZON2023-CIS?style=plastic"
    "DEBIAN11-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/DEBIAN11-CIS?style=plastic"
    "DEBIAN12-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/DEBIAN12-CIS?style=plastic"
-   "DEBIAN13-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/badge/Subscribers%20Only-0000FF?logo=ansible&labelColor=0000FF"
+   "DEBIAN13-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/DEBIAN13-CIS?style=plastic"
    "RHEL8-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/RHEL8-CIS?style=plastic"
    "RHEL9-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/github/v/release/ansible-lockdown/RHEL9-CIS?style=plastic"
    "RHEL10-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/github/v/release/ansible-lockdown/RHEL10-CIS?style=plastic"
    "SUSE15-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/github/v/release/ansible-lockdown/SUSE15-CIS?style=plastic"
+   "SUSE16-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/github/v/release/ansible-lockdown/SUSE16-CIS?style=plastic"
    "UBUNTU22-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU22-CIS?style=plastic"
    "UBUNTU24-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU24-CIS?style=plastic"
+   "UBUNTU26-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU26-CIS?style=plastic"
 
 .. csv-table:: CIS Windows Benchmark Availability
    :header: "Benchmark", "Maintained", "Remediate", "Audit", "Release"
@@ -74,10 +76,12 @@ Archived Roles
 .. _RHEL9-CIS: https://github.com/ansible-lockdown/RHEL9-CIS
 .. _RHEL10-CIS: https://github.com/ansible-lockdown/RHEL10-CIS
 .. _SUSE15-CIS: https://github.com/ansible-lockdown/SUSE15-CIS
+.. _SUSE16-CIS: https://github.com/ansible-lockdown/SUSE16-CIS
 .. _UBUNTU18-CIS: https://github.com/ansible-lockdown/UBUNTU18-CIS
 .. _UBUNTU20-CIS: https://github.com/ansible-lockdown/UBUNTU20-CIS
 .. _UBUNTU22-CIS: https://github.com/ansible-lockdown/UBUNTU22-CIS
 .. _UBUNTU24-CIS: https://github.com/ansible-lockdown/UBUNTU24-CIS
+.. _UBUNTU26-CIS: https://github.com/ansible-lockdown/UBUNTU26-CIS
 
 .. _Windows-2016-CIS: https://github.com/ansible-lockdown/Windows-2016-CIS
 .. _Windows-2019-CIS: https://github.com/ansible-lockdown/Windows-2019-CIS

--- a/docs/source/CIS/CIS_table.rst
+++ b/docs/source/CIS/CIS_table.rst
@@ -17,10 +17,10 @@ Operating Systems
    "RHEL9-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/github/v/release/ansible-lockdown/RHEL9-CIS?style=plastic"
    "RHEL10-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/github/v/release/ansible-lockdown/RHEL10-CIS?style=plastic"
    "SUSE15-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/github/v/release/ansible-lockdown/SUSE15-CIS?style=plastic"
-   "SUSE16-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/github/v/release/ansible-lockdown/SUSE16-CIS?style=plastic"
+   "SUSE16-CIS_", "True", "True", "True", ".. image::  https://img.shields.io/badge/Subscribers%20Only-0000FF?logo=ansible&labelColor=0000FF"
    "UBUNTU22-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU22-CIS?style=plastic"
    "UBUNTU24-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU24-CIS?style=plastic"
-   "UBUNTU26-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU26-CIS?style=plastic"
+   "UBUNTU26-CIS_", "True", "True", "True", ".. image:: https://img.shields.io/badge/Coming%20Soon-0000FF?logo=ansible&labelColor=0000FF"
 
 .. csv-table:: CIS Windows Benchmark Availability
    :header: "Benchmark", "Maintained", "Remediate", "Audit", "Release"

--- a/docs/source/STIG/STIG_table.rst
+++ b/docs/source/STIG/STIG_table.rst
@@ -14,7 +14,7 @@ Operating Systems
    "RHEL10-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/badge/Subscribers%20Only-0000FF?logo=ansible&labelColor=0000FF"
    "UBUNTU22-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU22-STIG?style=plastic"
    "UBUNTU24-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU24-STIG?style=plastic"
-   "UBUNTU26-STIG", "True", "WIP", "WIP", ".. image:: https://img.shields.io/badge/Coming%20Soon-0000FF?logo=ansible&labelColor=0000FF"
+   "UBUNTU26-STIG_", "True", "WIP", "WIP", ".. image:: https://img.shields.io/badge/Coming%20Soon-0000FF?logo=ansible&labelColor=0000FF"
 
 .. csv-table:: STIG Windows Benchmark Availability
    :header: "Benchmark", "Maintained", "Remediate", "Audit", "Release"
@@ -75,6 +75,7 @@ Archived Roles
 .. _UBUNTU20-STIG: https://github.com/ansible-lockdown/UBUNTU20-STIG
 .. _UBUNTU22-STIG: https://github.com/ansible-lockdown/UBUNTU22-STIG
 .. _UBUNTU24-STIG: https://github.com/ansible-lockdown/UBUNTU24-STIG
+.. _UBUNTU26-STIG: https://github.com/ansible-lockdown/UBUNTU26-STIG
 
 .. _Windows-10-STIG: https://github.com/ansible-lockdown/Windows-10-STIG
 .. _Windows-11-STIG: https://github.com/ansible-lockdown/Windows-11-STIG

--- a/docs/source/STIG/STIG_table.rst
+++ b/docs/source/STIG/STIG_table.rst
@@ -11,10 +11,10 @@ Operating Systems
    "AMAZON2023-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/badge/Subscribers%20Only-0000FF?logo=ansible&labelColor=0000FF"
    "RHEL8-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/RHEL8-STIG?style=plastic"
    "RHEL9-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/RHEL9-STIG?style=plastic"
-   "UBUNTU18-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU18-STIG?style=plastic"
-   "UBUNTU20-STIG_", "True", "True", "N/A", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU20-STIG?style=plastic"
+   "RHEL10-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/RHEL10-STIG?style=plastic"
    "UBUNTU22-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU22-STIG?style=plastic"
    "UBUNTU24-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU24-STIG?style=plastic"
+   "UBUNTU26-STIG", "True", "WIP", "WIP", ".. image:: https://img.shields.io/badge/Coming%20Soon-0000FF?logo=ansible&labelColor=0000FF"
 
 .. csv-table:: STIG Windows Benchmark Availability
    :header: "Benchmark", "Maintained", "Remediate", "Audit", "Release"
@@ -25,7 +25,7 @@ Operating Systems
    "Windows-2016-STIG_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/Windows-2016-STIG?style=plastic"
    "Windows-2019-STIG_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/Windows-2019-STIG?style=plastic"
    "Windows-2022-STIG_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/Windows-2022-STIG?style=plastic"
-   "Windows-2025-STIG_", "True", "WIP", "WIP", "N/A"
+   "Windows-2025-STIG_", "True", "WIP", "WIP", ".. image:: https://img.shields.io/badge/Coming%20Soon-0000FF?logo=ansible&labelColor=0000FF"
 
 Networking
 ^^^^^^^^^^
@@ -35,6 +35,7 @@ Networking
    :widths: 25, 15, 15, 15, 20
 
    "Cisco-IOS-L2S_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/CISCO-IOS-L2S-STIG?style=plastic"
+   "Cisco-IOS-RTR_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/CISCO-IOS-RTR-STIG?style=plastic"
 
 Applications
 ^^^^^^^^^^^^
@@ -43,6 +44,7 @@ Applications
    :header: "Benchmark", "Maintained", "Remediate", "Audit", "Release"
    :widths: 25, 15, 15, 15, 20
 
+   "AAP2-STIG_", "True", "True", "False", ".. image:: https://img.shields.io/badge/Subscribers%20Only-0000FF?logo=ansible&labelColor=0000FF"
    "Apache-2.4-STIG_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/APACHE-2.4-STIG?style=plastic"
    "TOMCAT-9-STIG_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/TOMCAT-9-STIG?style=plastic"
    "Windows_Advance_Firewall-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/WinFWADV-STIG?style=plastic"
@@ -58,6 +60,8 @@ Archived Roles
    "RHEL5-STIG_", "False", "True", "False", "N/A"
    "RHEL6-STIG_", "False", "True", "False", "N/A"
    "RHEL7-STIG_", "False", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/RHEL7-STIG?style=plastic"
+   "UBUNTU18-STIG_", "False", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU18-STIG?style=plastic"
+   "UBUNTU20-STIG_", "False", "True", "N/A", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU20-STIG?style=plastic"
    "Windows-2008R2-Member-Server-STIG_", "False", "True", "False", "N/A"
    "Windows-2012-Member-Server-STIG_", "False", "True", "False", "N/A"
    "Windows-2012-Domain-Controller-STIG_", "False", "True", "False", "N/A"
@@ -66,6 +70,7 @@ Archived Roles
 .. _AMAZON2023-STIG: https://github.com/ansible-lockdown/AMAZON2023-STIG
 .. _RHEL8-STIG: https://github.com/ansible-lockdown/RHEL8-STIG
 .. _RHEL9-STIG: https://github.com/ansible-lockdown/RHEL9-STIG
+.. _RHEL10-STIG: https://github.com/ansible-lockdown/RHEL10-STIG
 .. _UBUNTU18-STIG: https://github.com/ansible-lockdown/UBUNTU18-STIG
 .. _UBUNTU20-STIG: https://github.com/ansible-lockdown/UBUNTU20-STIG
 .. _UBUNTU22-STIG: https://github.com/ansible-lockdown/UBUNTU22-STIG
@@ -79,7 +84,9 @@ Archived Roles
 .. _Windows-2025-STIG: https://github.com/ansible-lockdown/Windows-2025-STIG
 
 .. _Cisco-IOS-L2S: https://github.com/ansible-lockdown/CISCO-IOS-L2S-STIG
+.. _Cisco-IOS-RTR: https://github.com/ansible-lockdown/CISCO-IOS-RTR-STIG
 
+.. _AAP2-STIG: https://github.com/ansible-lockdown/AAP2-STIG
 .. _Apache-2.4-STIG: https://github.com/ansible-lockdown/APACHE-2.4-STIG
 .. _Postgres-9-STIG: https://github.com/ansible-lockdown/POSTGRES-9-STIG
 .. _TOMCAT-9-STIG: https://github.com/ansible-lockdown/TOMCAT-9-STIG

--- a/docs/source/STIG/STIG_table.rst
+++ b/docs/source/STIG/STIG_table.rst
@@ -8,10 +8,10 @@ Operating Systems
    :header: "Benchmark", "Maintained", "Remediate", "Audit", "Release"
    :widths: 25, 15, 15, 15, 20
 
-   "AMAZON2023-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/badge/Subscribers%20Only-0000FF?logo=ansible&labelColor=0000FF"
+   "AMAZON2023-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/AMAZON2023-STIG?style=plastic"
    "RHEL8-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/RHEL8-STIG?style=plastic"
    "RHEL9-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/RHEL9-STIG?style=plastic"
-   "RHEL10-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/RHEL10-STIG?style=plastic"
+   "RHEL10-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/badge/Subscribers%20Only-0000FF?logo=ansible&labelColor=0000FF"
    "UBUNTU22-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU22-STIG?style=plastic"
    "UBUNTU24-STIG_", "True", "True", "True", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/UBUNTU24-STIG?style=plastic"
    "UBUNTU26-STIG", "True", "WIP", "WIP", ".. image:: https://img.shields.io/badge/Coming%20Soon-0000FF?logo=ansible&labelColor=0000FF"
@@ -35,7 +35,7 @@ Networking
    :widths: 25, 15, 15, 15, 20
 
    "Cisco-IOS-L2S_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/CISCO-IOS-L2S-STIG?style=plastic"
-   "Cisco-IOS-RTR_", "True", "True", "False", ".. image:: https://img.shields.io/github/v/release/ansible-lockdown/CISCO-IOS-RTR-STIG?style=plastic"
+   "Cisco-IOS-RTR_", "True", "True", "False", "N/A"
 
 Applications
 ^^^^^^^^^^^^

--- a/docs/source/combined/molecule-testing.rst
+++ b/docs/source/combined/molecule-testing.rst
@@ -1,0 +1,244 @@
+Molecule - Linux-Based Container Testing
+========================================
+
+`Molecule <https://ansible.readthedocs.io/projects/molecule/>`_ is the framework used to
+develop and test the Ansible Lockdown roles. It provisions a disposable target, applies the
+role against it, and asserts the resulting system state. For the Lockdown roles the target is
+a **Linux-based container** (Docker is the default driver; Podman also works), which makes the
+scenarios fast to spin up and tear down and lets the same tests run locally and in CI.
+
+Every remediation and audit role in the project ships a ``molecule/`` directory so
+contributors can validate changes locally before opening a pull request, and so the same
+scenarios can be exercised in the pipelines.
+
+Two stages do most of the work:
+
+- **converge** - run the role against the container target, exactly as a user would.
+- **verify** - assert that the container reached the expected state after remediation.
+
+.. note::
+
+   Because the targets are Linux containers, container-detection facts are set and tasks
+   guarded by ``when: not system_is_container`` are skipped. This keeps the scenarios light
+   but means they do not exercise every code path - see `Platforms and ARM64`_ below.
+
+Prerequisites
+-------------
+
+Molecule runs from a workstation with Python, Ansible, and a container runtime available.
+Docker is the default driver used across the roles; Podman also works.
+
+.. code-block:: console
+
+   # Python tooling (a virtualenv is recommended)
+   pip install molecule molecule-plugins[docker] ansible-core
+
+   # A container runtime must be installed and running
+   docker info
+
+   # Confirm molecule sees the docker driver
+   molecule --version
+
+.. note::
+
+   The container images a scenario uses are declared in each role's ``molecule/<scenario>/molecule.yml``
+   and are aligned with the platforms listed in the role's ``meta/main.yml``. Use an image that
+   matches the benchmark you are testing (for example a RHEL 9 image for ``RHEL9-CIS``).
+
+Repository layout
+-----------------
+
+A role's Molecule configuration lives under ``molecule/`` with one directory per scenario.
+Each scenario directory holds four files:
+
+.. code-block:: text
+
+   molecule/
+   └── default/
+       ├── molecule.yml     # driver, platform image(s), host_vars, and verifier
+       ├── prepare.yml      # bootstrap the container (python + packages) before the role runs
+       ├── converge.yml     # playbook that applies the role (sets required variables)
+       └── verify.yml       # assertions run against the converged target
+
+- **prepare.yml** brings a minimal container image up to a testable baseline: it bootstraps
+  Python with ``ansible.builtin.raw`` (so Ansible can run at all), then installs the packages
+  the benchmark expects to be present (for example auditd, aide, firewalld, and crypto-policies).
+  Minimal images ship far fewer packages than a real host, so this step is what makes the
+  role's tasks meaningful.
+- **converge.yml** applies the role and sets the variables a container run needs -
+  ``setup_audit: true`` and ``run_audit: true`` so the paired audit runs, plus container
+  affordances such as ``system_is_container: true`` and ``skip_reboot: true``. It typically
+  sets a root password in ``pre_tasks`` so PAM hardening does not lock the session out.
+- **verify.yml** asserts the resulting state when the scenario's verifier is ``ansible``.
+
+Scenarios let a single role be tested in more than one way. Coverage differs between the
+CIS and STIG roles:
+
+- **CIS operating-system roles** are the most consistent, typically shipping ``default``,
+  ``localhost``, and ``wsl`` scenarios. ``RHEL9-CIS`` additionally provides a ``ubi`` scenario.
+- **STIG operating-system roles** are generally thinner, shipping a ``default`` scenario;
+  ``RHEL9-STIG`` also provides a ``ubi`` scenario.
+
+Scenario configuration
+----------------------
+
+Because the roles harden systemd-managed services, the container must run a real init system.
+A representative ``molecule.yml`` platform block (from ``RHEL9-CIS``) shows the settings that
+make this work:
+
+.. code-block:: yaml
+
+   driver:
+     name: docker
+   platforms:
+     - name: rhel9-cis-qa
+       image: rockylinux/rockylinux:9-ubi-init   # an "-init" image that ships systemd
+       command: /usr/sbin/init                   # PID 1 is systemd, not a shell
+       pre_build_image: true
+       privileged: true
+       cgroupns_mode: host
+       volumes:
+         - /sys/fs/cgroup:/sys/fs/cgroup:rw
+       tmpfs:
+         - /run
+         - /tmp
+       capabilities:
+         - SYS_ADMIN
+   provisioner:
+     name: ansible
+     inventory:
+       host_vars:
+         rhel9-cis-qa:
+           setup_audit: true
+           run_audit: true
+           system_is_container: true
+           skip_reboot: true
+   verifier:
+     name: ansible
+
+.. important::
+
+   The ``-init`` image, ``command: /usr/sbin/init``, ``privileged: true``,
+   ``cgroupns_mode: host``, the cgroup volume mount, and the ``/run`` + ``/tmp`` tmpfs mounts
+   are all required for systemd - and therefore any service-oriented control - to work inside
+   the container. Omitting them causes hard-to-diagnose failures in tasks that manage services.
+
+.. note::
+
+   Not every role uses ``verify.yml`` for assertions. The verifier is set by the scenario's
+   ``molecule.yml`` ``verifier:`` key - ``RHEL9-CIS`` uses ``ansible`` with a ``verify.yml``,
+   while some roles rely on the paired audit (Goss) profile as the verification step instead.
+   Check the ``verifier`` setting and whether ``verify.yml`` is present before assuming a
+   scenario asserts state on its own. Use an existing role such as ``RHEL9-CIS`` as a working
+   reference when adding a new scenario.
+
+Running tests
+-------------
+
+Run Molecule from the root of the role. A scenario other than ``default`` is selected with
+``-s <scenario>``.
+
+.. code-block:: console
+
+   # Full lifecycle: create -> converge -> idempotence -> verify -> destroy
+   molecule test
+
+   # Iterating during development (leave the instance running):
+   molecule create      # provision the target
+   molecule converge    # apply the role
+   molecule verify      # run the assertions
+   molecule destroy     # tear the target down
+
+   # Target a named scenario
+   molecule test -s localhost
+
+   # Shell into the running target to debug a failure
+   molecule login
+
+.. important::
+
+   Always ``molecule destroy`` before re-running ``molecule converge`` to guarantee a clean
+   target. Stale containers are a common cause of "instance is not running" style errors.
+
+Idempotency
+-----------
+
+Remediation roles must be idempotent: a second run should change nothing. Molecule checks
+this with the idempotence action, which runs ``converge`` a second time and fails if any task
+reports a change.
+
+.. code-block:: console
+
+   molecule idempotence
+
+   # or exercise it as part of the full lifecycle
+   molecule test
+
+If the second run reports changes, the offending tasks need ``changed_when`` corrected or the
+remediation logic adjusted so it detects the already-compliant state. See the idempotency
+guidance in the :doc:`remediation FAQ </remediate/rem-faq>` for common causes.
+
+Linting integration
+-------------------
+
+Molecule is one layer of a wider quality gate. Pull requests are also expected to pass
+``ansible-lint``, ``yamllint``, and the repository ``pre-commit`` hooks. Rather than duplicate
+that guidance here, see the linting and standards sections of the
+:doc:`remediation development guide </remediate/rem_development>` and the
+:doc:`audit development guide </audit/audit_development>`.
+
+Platforms and ARM64
+-------------------
+
+The platform images a scenario runs against are driven by the role's ``meta/main.yml`` and the
+scenario ``molecule.yml``. Container-based scenarios behave differently from full virtual
+machines in ways that affect testing:
+
+- Container targets set container-detection facts, so tasks guarded by ``when: not system_is_container``
+  are skipped. See the :doc:`container and Docker guide </container-guide>` for how this
+  affects coverage.
+- ARM64/aarch64 targets have auditd syscall differences that cause some audit assertions to
+  behave differently than on x86_64. See the :doc:`ARM64 guide </arm64-guide>`.
+
+.. important::
+
+   Because container scenarios skip container-gated tasks, they do not exercise every code
+   path. Where possible, complement Molecule container runs with testing on a full VM or a real
+   CI runner so container-gated logic is also covered.
+
+CI/CD pipelines
+---------------
+
+The same scenarios run in the project's GitHub Actions pipelines on pull requests, so a change
+that passes locally with ``molecule test`` should also pass in CI. When CI fails but a local
+Molecule run passes, suspect a difference in the test substrate (for example a missing package
+or an unresolvable hostname on the CI image) rather than the role logic.
+
+Troubleshooting
+---------------
+
+**Error:** ``instance is not running`` or a stale container is reused.
+
+Run ``molecule destroy`` (or ``molecule reset``) and converge again from a clean state.
+
+**Symptom:** Idempotence action fails on the second converge.
+
+A task is reporting a change on an already-compliant system. Inspect the changed tasks in the
+output and correct ``changed_when`` or the remediation condition.
+
+**Symptom:** Audit/verify assertions fail only in a container or only on ARM64.
+
+Expected for container-gated tasks and for auditd syscall differences on ARM64. Confirm against
+the :doc:`container </container-guide>` and :doc:`ARM64 </arm64-guide>` guides before treating
+it as a role defect.
+
+Best Practices
+--------------
+
+1. **Start clean** - ``molecule destroy`` before each fresh ``converge``.
+2. **Test idempotency** - a second converge must report zero changes.
+3. **Match the image to the benchmark** - use an image for the OS/version the role targets.
+4. **Do not rely on containers alone** - container-gated tasks are skipped; also test on a VM
+   or CI runner where practical.
+5. **Run the full gate** - pass ``ansible-lint``, ``yamllint``, and ``pre-commit`` alongside
+   Molecule before opening a pull request.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -18,3 +18,4 @@ We do ask the following:
 
    audit/audit_development.rst
    remediate/rem_development.rst
+   combined/molecule-testing.rst


### PR DESCRIPTION
Please ensure that you have understood the contributing guide, and that all commits are signed-off and gpg signed.

**Overall Review of Changes:**
Reconciles the CIS and STIG benchmark availability tables with the canonical `ansible-lockdown/.github` org profile, and adds a new Molecule testing guide.

- CIS table: added SUSE16-CIS and UBUNTU26-CIS; corrected the DEBIAN13-CIS and Windows-2025-CIS Release badges to their live releases; set SUSE16-CIS Release to Subscribers Only and UBUNTU26-CIS Release to Coming Soon.
- STIG table: added RHEL10-STIG, UBUNTU26-STIG (pre-set link), AAP2-STIG, and Cisco-IOS-RTR; moved UBUNTU18-STIG and UBUNTU20-STIG into the Archived section; set Windows-2025-STIG and UBUNTU26-STIG Release to Coming Soon; corrected the AMAZON2023-STIG Release badge to its live release; set RHEL10-STIG Release to Subscribers Only and Cisco-IOS-RTR Release to N/A.
- New page `combined/molecule-testing.rst` ("Molecule - Linux-Based Container Testing"), wired into the Development toctree via `contributing.rst`.

**Issue Fixes:**
N/A

**Enhancements:**
- New Molecule testing documentation page for contributors, covering prerequisites, scenario layout, the systemd container configuration, running tests, idempotency, linting, and ARM64/container caveats.
- Benchmark tables brought back in line with the org profile: new benchmarks added, retired ones relocated, and Release badges corrected against the live repositories.

**How has this been tested?:**
Built locally with Sphinx (`sphinx-build`); the build succeeded with no new warnings. rstcheck and doc8 pass at their configured levels. Every changed benchmark link and Release badge was verified against the live repositories with the `gh` CLI.

Thank you.
